### PR TITLE
BREAKING: move zookeeper config parameters to extensible config hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,22 @@
 
 #### Table of Contents
 
-1. [Description](#description)
-2. [Setup - The basics of getting started with zookeeperd](#setup)
-    * [Setup requirements](#setup-requirements)
-    * [Beginning with zookeeperd](#beginning-with-zookeeperd)
-3. [Usage - Configuration options and additional functionality](#usage)
-4. [Reference - An under-the-hood peek at what the module is doing and how](#reference)
-5. [Limitations - OS compatibility, etc.](#limitations)
-6. [Development - Guide for contributing to the module](#development)
+- [zookeeperd](#zookeeperd)
+      - [Table of Contents](#table-of-contents)
+  - [Description](#description)
+  - [Setup](#setup)
+    - [Setup Requirements](#setup-requirements)
+    - [Beginning with zookeeperd](#beginning-with-zookeeperd)
+  - [Usage](#usage)
+    - [Automatic cluster configuration](#automatic-cluster-configuration)
+    - [Manual configuration](#manual-configuration)
+    - [Using zookeeperd fact](#using-zookeeperd-fact)
+  - [Configuration](#configuration)
+    - [zoo.cfg](#zoocfg)
+  - [Reference](#reference)
+  - [Limitations](#limitations)
+  - [Development](#development)
+  - [Donate](#donate)
 
 ## Description
 
@@ -37,7 +45,9 @@ Install the module and its dependencies to your environment. Include the module 
 
 ## Usage
 
-To create a zookeeper cluster, the easies way is, to include the module to your manifest, enable autoconfiguration and set an ensamble name  on all nodes of the cluster.
+### Automatic cluster configuration
+
+This module enables to automatically create the configurations of zookeeper instances belonging to the same ensamble. To do so, enable autoconfiguration and set an ensamble name on all nodes of the cluster.
 
 ```puppet
 class{ zookeeperd:
@@ -46,7 +56,9 @@ class{ zookeeperd:
 }
 ````
 
-The above example will install zookeeper to all nodes this manifest applies to and configure all instances having the same ensamble name to one cluster. Note, that puppet needs at least two runs to get the configuration ready: the first run will export the node definitions, the second will collect all nodes.
+This will install zookeeper to all nodes this manifest applies to and configure all instances having the same ensamble name to one cluster. Note, that puppet needs at least two runs to get the configuration ready: the first run will export the node definitions, the second will collect all nodes. This is done by exporting ```zookeeperd::node``` resources tagged with their ensamble and collecting the same resources having the matching ensamble tag. Each ```zookeeperd::node``` resource will create one ```server``` entry in the zoo.cfg configuration telling zookeeper the list of nodes within the cluster.
+
+### Manual configuration
 
 If you don't trust your PuppetDB, or does not want stored configs on your PupppetMaster, you may add pass the list of nodes to the module through nodes parameter.
 
@@ -71,6 +83,12 @@ The module provides a custom fact which calculates a unique ID for all nodes. Th
 
 Zookeeper documentation, however, states myid must between 1..255, the software itself is treating this as unsigned long, and it is not used for any logic nor arithmetic.
 
+## Configuration
+
+### zoo.cfg
+
+The main configuration file of zookeeper, the zoo.cfg is created by taking key-value pairs from ```zookeeperd::config``` hash. The module proves default values with the minimum parameters needed for zookeeper.
+
 ## Reference
 
 The module code is documented using puppet-strings. Visit https://rtib.github.io/puppet-zookeeperd/ to access detailed code documentation.
@@ -83,10 +101,10 @@ This is where you list OS compatibility, version compatibility, etc. If there ar
 
 Puppet modules on the Puppet Forge are open projects, and community contributions are essential for keeping them great. Please follow the usual guidelines when contributing changes.
 1. fork the repository on GitHub
-1. make your improvements, preferably to a feature branch
-1. rebase your changes to the head of the master branch
-1. squash your changes into a single commit
-1. file a pull request and check the result of Travis-CI tests
+2. make your improvements, preferably to a feature branch
+3. rebase your changes to the head of the master branch
+4. squash your changes into a single commit
+5. file a pull request and check the result of Travis-CI tests
 
 ## Donate
 

--- a/data/Debian.yaml
+++ b/data/Debian.yaml
@@ -3,7 +3,6 @@ zookeeperd::package_names:
   - zookeeper
   - zookeeperd
   - zookeeper-bin
-zookeeperd::data_dir: '/var/zookeeper'
 zookeeperd::user: 'zookeeper'
 zookeeperd::group: 'zookeeper'
 zookeeperd::cfg_path: '/etc/zookeeper/conf/zoo.cfg'

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,13 +1,16 @@
 ---
 zookeeperd::ensure: present
 zookeeperd::manage_packages: true
-zookeeperd::tick_time: 2000
-zookeeperd::init_limit: 10
-zookeeperd::sync_limit: 5
-zookeeperd::max_client_cnxns: 500
-zookeeperd::client_port: 2181
-zookeeperd::force_sync: true
 zookeeperd::enable_autoconfig: false
 zookeeperd::manage_service: true
 zookeeperd::service_enabled: true
 zookeeperd::service_running: true
+
+zookeeperd::config:
+  dataDir: "%{hiera('zookeeperd::data_dir')}"
+  tickTime: 2000
+  initLimit: 10
+  syncLimit: 5
+  maxClientCnxns: 500
+  clientPort: 2181
+  forceSync: 'yes'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,12 +18,7 @@
 # @param user username of zookeeper service
 # @param group groupname of zookeeper service
 # @param cfg_path path to configuration directory
-# @param tick_time zookeeper configuration parameter
-# @param init_limit zookeeper configuration parameter
-# @param sync_limit zookeeper configuration parameter
-# @param max_client_cnxns zookeeper configuration parameter
-# @param client_port zookeeper configuration parameter
-# @param force_sync zookeeper configuration parameter
+# @param config parameter to generate zoo.cfg configration file
 # @param manage_service enable puppet to manage the zookeeper serivce
 # @param service_name name of the service to control
 # @param service_enabled enable service at boot time
@@ -41,13 +36,8 @@ class zookeeperd (
   Variant[Integer,String]     $user,
   Variant[Integer,String]     $group,
   Stdlib::Absolutepath        $cfg_path,
-  # zoo.cfg general params
-  Integer                     $tick_time,
-  Integer                     $init_limit,
-  Integer                     $sync_limit,
-  Integer                     $max_client_cnxns,
-  Integer[1025,65534]         $client_port,
-  Boolean                     $force_sync,
+  # zoo.cfg
+  Hash[String, Scalar]        $config,
   # service management
   Boolean                     $manage_service,
   String                      $service_name,

--- a/metadata.json
+++ b/metadata.json
@@ -10,19 +10,19 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.0.0 < 5.0.0"
+      "version_requirement": ">= 5.0.0 < 6.0.0"
     },
     {
       "name": "puppetlabs-concat",
-      "version_requirement": ">= 4.0.0 < 5.0.0"
+      "version_requirement": ">= 5.0.0 < 6.0.0"
     }
   ],
-  "data_provider": "hiera",
   "operatingsystem_support": [
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "8"
+        "8",
+        "9"
       ]
     },
     {

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -64,11 +64,10 @@ describe 'zookeeperd class' do
       its(:args) { is_expected.to match %r{org.apache.zookeeper.server.quorum.QuorumPeerMain} }
     end
   end
-  # Not working on Travis-CI
-  #  context 'client port listening' do
-  #    describe port(2181), retry: 10, retry_wait: 5 do
-  #      it { is_expected.to be_listening.with('tcp') }
-  #    end
-  #  end
+  context 'client port listening' do
+    describe port(2181), retry: 10, retry_wait: 5 do
+      it { is_expected.to be_listening.with('tcp') }
+    end
+  end
   # TODO: add tests here!
 end # describe 'zookeeperd class'

--- a/spec/classes/zookeeperd_spec.rb
+++ b/spec/classes/zookeeperd_spec.rb
@@ -18,6 +18,37 @@ describe 'zookeeperd' do
         it { is_expected.to contain_package('zookeeper-bin') }
         it { is_expected.to contain_package('zookeeperd') }
       end
+
+      describe 'zookeeperd::config' do
+        it {
+          is_expected.to contain_file('/var/lib/zookeeper')
+            .with(
+              'ensure' => 'directory',
+            )
+        }
+        it {
+          is_expected.to contain_file('/var/lib/zookeeper/version-2')
+            .with(
+              'ensure' => 'directory',
+            )
+        }
+        it {
+          is_expected.to contain_file('/var/lib/zookeeper/myid')
+            .with(
+              'ensure' => 'file',
+            )
+        }
+        it do
+          is_expected.to contain_concat__fragment('zoo.cfg head')
+            .with_content(%r{tickTime=2000})
+            .with_content(%r{initLimit=10})
+            .with_content(%r{syncLimit=5})
+            .with_content(%r{dataDir=/var/lib/zookeeper})
+            .with_content(%r{maxClientCnxns=500})
+            .with_content(%r{clientPort=2181})
+            .with_content(%r{forceSync=yes})
+        end
+      end
     end
   end
 end

--- a/templates/zoo.cfg.head.epp
+++ b/templates/zoo.cfg.head.epp
@@ -1,10 +1,6 @@
 # This file is controlled by Puppet module trepasi-zookeeperd
 # DO NOT EDIT!
 
-tickTime=<%= $zookeeperd::tick_time %>
-initLimit=<%= $zookeeperd::init_limit %>
-syncLimit=<%= $zookeeperd::sync_limit %>
-dataDir=<%= $zookeeperd::data_dir %>
-maxClientCnxns=<%= $zookeeperd::max_client_cnxns %>
-clientPort=<%= $zookeeperd::client_port %>
-forceSync=<%= $zookeeperd::force_sync ? { true => "yes", default => "no" } %>
+<% $zookeeperd::config.each |String $k, Scalar $v| { -%>
+<%= $k %>=<%= $v %>
+<% } -%>


### PR DESCRIPTION
This will solve #4 .

Parameter containing zookeeper configuration and be transported into zoo.cfg are moved to zookeepers::config parameter hash. This separates the zoo.cfg parameters from other module parameter and enables to extend the hash.

As this is changing the module API, this is a breaking change requiring review of Puppet and/or Hiera contents.