### PR TITLE
BREAKING: replace enable_autoconfig feature toggle by type matching

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -31,7 +31,7 @@ class zookeeperd::config {
     content => epp('zookeeperd/zoo.cfg.head.epp'),
     order   => 1,
   }
-  if $zookeeperd::enable_autoconfig {
+  if $zookeeperd::ensamble =~ String {
     @@zookeeperd::node{ "${zookeeperd::ensamble} node ${zookeeperd::nodename}":
       ensure   => $zookeeperd::ensure,
       ensamble => $zookeeperd::ensamble,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,7 +31,6 @@
 # @param service_enabled enable service at boot time
 # @param service_running ensure running of the service
 # @param ensamble name of the ensamble
-# @param enable_autoconfig enable puppet to manage cluster configuration
 # @param nodes list of nodes, if autoconfiguration disable
 # @param myid node id of zookeeper instance
 # @param nodename fqdn of this node
@@ -55,7 +54,6 @@ class zookeeperd (
   Boolean                     $service_enabled = true,
   Boolean                     $service_running = true,
   # cluster configuration parameters
-  Boolean                     $enable_autoconfig = false,
   Optional[String]            $ensamble = undef,
   Hash                        $nodes = {},
   # Parameter having facts default


### PR DESCRIPTION
Closes #7 without breaking the API.

Autoconfig will be enabled as soon ensamble parameter is set. This obsoletes setting of enable_autoconfig parameter.