### PR TITLE
update requirements and dependencies

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -9,37 +9,39 @@
   "issues_url": "https://github.com/rtib/puppet-zookeeperd/issues",
   "dependencies": [
     {
-      "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 5.0.0 < 6.0.0"
+      "name": "puppetlabs/stdlib",
+      "version_requirement": ">= 6.0.0 < 8.0.0"
     },
     {
-      "name": "puppetlabs-concat",
-      "version_requirement": ">= 5.0.0 < 6.0.0"
+      "name": "puppetlabs/concat",
+      "version_requirement": ">= 6.0.0 < 8.0.0"
     },
     {
       "name": "camptocamp/systemd",
-      "version_requirement": ">= 2.0.0 < 3.0.0"
+      "version_requirement": ">= 3.0.0 < 4.0.0"
     }
   ],
   "operatingsystem_support": [
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "8",
-        "9"
+        "9",
+        "10"
       ]
     },
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "16.04"
+        "16.04",
+        "18.04",
+        "20.04"
       ]
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.0.0 < 7.0.0"
+      "version_requirement": ">= 6.0.0 < 8.0.0"
     }
   ],
   "pdk-version": "2.1.0",

--- a/spec/default_module_facts.yml
+++ b/spec/default_module_facts.yml
@@ -1,6 +1,7 @@
 ---
 networking:
-  ip: "172.16.254.254"
+  ip: 172.16.254.254
+  fqdn: test.example.org
 zookeeperd:
   myid: 2886795006
 service_provider: systemd


### PR DESCRIPTION
Breaking changes:
* Puppet-5 support dropped
* Debian-8 support dropped
Improvements:
* Puppet-7 support added
* Debian-10, Ubuntu 18.04 and 20.04 support added