### PR TITLE
drop ubuntu 16.04

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -32,7 +32,6 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "16.04",
         "18.04",
         "20.04"
       ]


### PR DESCRIPTION
standard support for 16.04 LTS has ended April 2021